### PR TITLE
Start refactoring of Envoy

### DIFF
--- a/Diplomat.blade.php
+++ b/Diplomat.blade.php
@@ -1,0 +1,13 @@
+@servers(['web' => ['127.0.0.1']])
+
+@task('foo', ['on' => 'web'])
+block="This is some text,
+    whose indentation should not
+    be modified by diplomat.
+"
+
+cat > "/home/sanuj/Projects/diplomat/examples/temp.out" << EOF
+${block}
+EOF
+
+@endtask

--- a/Envoy.blade.php
+++ b/Envoy.blade.php
@@ -1,5 +1,0 @@
-@servers(['web' => ['192.168.1.1']])
-
-@task('foo', ['on' => 'web'])
-    ls -la
-@endtask

--- a/diplomat
+++ b/diplomat
@@ -7,7 +7,7 @@ if (file_exists(__DIR__.'/vendor/autoload.php')) {
     require __DIR__.'/../../autoload.php';
 }
 
-$app = new Symfony\Component\Console\Application('Laravel Envoy', '1.3.2');
+$app = new Symfony\Component\Console\Application('Diplomat', '1.3.2');
 
 $app->add(new Sanuj\Diplomat\Console\RunCommand);
 $app->add(new Sanuj\Diplomat\Console\SshCommand);

--- a/envoy
+++ b/envoy
@@ -9,9 +9,9 @@ if (file_exists(__DIR__.'/vendor/autoload.php')) {
 
 $app = new Symfony\Component\Console\Application('Laravel Envoy', '1.3.2');
 
-$app->add(new Laravel\Envoy\Console\RunCommand);
-$app->add(new Laravel\Envoy\Console\SshCommand);
-$app->add(new Laravel\Envoy\Console\InitCommand);
-$app->add(new Laravel\Envoy\Console\TasksCommand);
+$app->add(new Sanuj\Diplomat\Console\RunCommand);
+$app->add(new Sanuj\Diplomat\Console\SshCommand);
+$app->add(new Sanuj\Diplomat\Console\InitCommand);
+$app->add(new Sanuj\Diplomat\Console\TasksCommand);
 
 $app->run();

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,7 +11,7 @@
          syntaxCheck="false"
         >
     <testsuites>
-        <testsuite name="Laravel Envoy Test Suite">
+        <testsuite name="Diplomat Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,3 @@
-# Laravel Envoy
+# Diplomat
 
-Elegant SSH tasks for PHP.
-
-Official documentation [is located here](http://laravel.com/docs/envoy).
+Diplomatic SSH tasks for PHP.

--- a/scripts/script.sh
+++ b/scripts/script.sh
@@ -1,13 +1,10 @@
-@servers(['web' => ['127.0.0.1']])
+#!/usr/bin/env bash
 
-@task('foo', ['on' => 'web'])
 block="This is some text,
     whose indentation should not
-    be modified by diplomat.
+    be modified by dimplomat.
 "
 
 cat > "/home/sanuj/Projects/diplomat/scripts/temp.out" << EOF
 ${block}
 EOF
-
-@endtask

--- a/scripts/script.sh
+++ b/scripts/script.sh
@@ -2,9 +2,10 @@
 
 block="This is some text,
     whose indentation should not
-    be modified by dimplomat.
+    be modified by diplomat.
 "
 
 cat > "/home/sanuj/Projects/diplomat/scripts/temp.out" << EOF
 ${block}
 EOF
+echo 'IT WORKS!'

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -54,7 +54,7 @@ class Compiler
     protected $contentTags = ['{{', '}}'];
 
     /**
-     * Compile the given Envoy template contents.
+     * Compile the given Diplomat template contents.
      *
      * @param  string  $value
      * @param  bool  $serversOnly
@@ -74,7 +74,7 @@ class Compiler
     }
 
     /**
-     * Compile Envoy sets into valid PHP.
+     * Compile Diplomat sets into valid PHP.
      *
      * @param  string  $value
      * @return string
@@ -85,7 +85,7 @@ class Compiler
     }
 
     /**
-     * Compile Envoy imports into valid PHP.
+     * Compile Diplomat imports into valid PHP.
      *
      * @param  string  $value
      * @return string
@@ -98,7 +98,7 @@ class Compiler
     }
 
     /**
-     * Compile Envoy comments into valid PHP.
+     * Compile Diplomat comments into valid PHP.
      *
      * @param  string  $value
      * @return string
@@ -111,7 +111,7 @@ class Compiler
     }
 
     /**
-     * Compile Envoy echos into valid PHP.
+     * Compile Diplomat echos into valid PHP.
      *
      * @param  string  $value
      * @return string
@@ -154,7 +154,7 @@ class Compiler
     }
 
     /**
-     * Compile Envoy structure openings into valid PHP.
+     * Compile Diplomat structure openings into valid PHP.
      *
      * @param  string  $value
      * @return string
@@ -167,7 +167,7 @@ class Compiler
     }
 
     /**
-     * Compile Envoy structure closings into valid PHP.
+     * Compile Diplomat structure closings into valid PHP.
      *
      * @param  string  $value
      * @return string
@@ -180,7 +180,7 @@ class Compiler
     }
 
     /**
-     * Compile Envoy else statements into valid PHP.
+     * Compile Diplomat else statements into valid PHP.
      *
      * @param  string  $value
      * @return string
@@ -193,7 +193,7 @@ class Compiler
     }
 
     /**
-     * Compile Envoy unless statements into valid PHP.
+     * Compile Diplomat unless statements into valid PHP.
      *
      * @param  string  $value
      * @return string
@@ -206,7 +206,7 @@ class Compiler
     }
 
     /**
-     * Compile Envoy end unless statements into valid PHP.
+     * Compile Diplomat end unless statements into valid PHP.
      *
      * @param  string  $value
      * @return string
@@ -258,7 +258,7 @@ class Compiler
     }
 
     /**
-     * Compile Envoy server statements into valid PHP.
+     * Compile Diplomat server statements into valid PHP.
      *
      * @param  string  $value
      * @return string
@@ -271,7 +271,7 @@ class Compiler
     }
 
     /**
-     * Compile Envoy macro start statements into valid PHP.
+     * Compile Diplomat macro start statements into valid PHP.
      *
      * @param  string  $value
      * @return string
@@ -288,7 +288,7 @@ class Compiler
     }
 
     /**
-     * Compile Envoy macro stop statements into valid PHP.
+     * Compile Diplomat macro stop statements into valid PHP.
      *
      * @param  string  $value
      * @return string
@@ -305,7 +305,7 @@ class Compiler
     }
 
     /**
-     * Compile Envoy task start statements into valid PHP.
+     * Compile Diplomat task start statements into valid PHP.
      *
      * @param  string  $value
      * @return string
@@ -318,7 +318,7 @@ class Compiler
     }
 
     /**
-     * Compile Envoy task stop statements into valid PHP.
+     * Compile Diplomat task stop statements into valid PHP.
      *
      * @param  string  $value
      * @return string
@@ -331,7 +331,7 @@ class Compiler
     }
 
     /**
-     * Compile Envoy after statements into valid PHP.
+     * Compile Diplomat after statements into valid PHP.
      *
      * @param  string  $value
      * @return string
@@ -344,7 +344,7 @@ class Compiler
     }
 
     /**
-     * Compile Envoy after stop statements into valid PHP.
+     * Compile Diplomat after stop statements into valid PHP.
      *
      * @param  string  $value
      * @return string
@@ -355,7 +355,7 @@ class Compiler
     }
 
     /**
-     * Compile Envoy finished statements into valid PHP.
+     * Compile Diplomat finished statements into valid PHP.
      *
      * @param  string  $value
      * @return string
@@ -368,7 +368,7 @@ class Compiler
     }
 
     /**
-     * Compile Envoy finished stop statements into valid PHP.
+     * Compile Diplomat finished stop statements into valid PHP.
      *
      * @param  string  $value
      * @return string
@@ -379,7 +379,7 @@ class Compiler
     }
 
     /**
-     * Compile Envoy error statements into valid PHP.
+     * Compile Diplomat error statements into valid PHP.
      *
      * @param  string  $value
      * @return string
@@ -392,7 +392,7 @@ class Compiler
     }
 
     /**
-     * Compile Envoy error stop statements into valid PHP.
+     * Compile Diplomat error stop statements into valid PHP.
      *
      * @param  string  $value
      * @return string
@@ -403,7 +403,7 @@ class Compiler
     }
 
     /**
-     * Compile Envoy HipChat statements into valid PHP.
+     * Compile Diplomat HipChat statements into valid PHP.
      *
      * @param  string  $value
      * @return string
@@ -416,7 +416,7 @@ class Compiler
     }
 
     /**
-     * Compile Envoy Slack statements into valid PHP.
+     * Compile Diplomat Slack statements into valid PHP.
      *
      * @param  string  $value
      * @return string
@@ -429,7 +429,7 @@ class Compiler
     }
 
     /**
-     * Initialize the variables included in the Envoy template.
+     * Initialize the variables included in the Diplomat template.
      *
      * @param  string  $value
      * @return string
@@ -446,7 +446,7 @@ class Compiler
     }
 
     /**
-     * Get the regular expression for a generic Envoy function.
+     * Get the regular expression for a generic Diplomat function.
      *
      * @param  string  $function
      * @return string
@@ -457,7 +457,7 @@ class Compiler
     }
 
     /**
-     * Get the regular expression for a generic Envoy function.
+     * Get the regular expression for a generic Diplomat function.
      *
      * @param  string  $function
      * @return string
@@ -468,7 +468,7 @@ class Compiler
     }
 
     /**
-     * Create a plain Envoy matcher.
+     * Create a plain Diplomat matcher.
      *
      * @param  string  $function
      * @return string

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Laravel\Envoy;
+namespace Sanuj\Diplomat;
 
 class Compiler
 {
@@ -412,7 +412,7 @@ class Compiler
     {
         $pattern = $this->createMatcher('hipchat');
 
-        return preg_replace($pattern, '$1 Laravel\Envoy\Hipchat::make$2->task($task)->send();', $value);
+        return preg_replace($pattern, '$1 Sanuj\Diplomat\Hipchat::make$2->task($task)->send();', $value);
     }
 
     /**
@@ -425,7 +425,7 @@ class Compiler
     {
         $pattern = $this->createMatcher('slack');
 
-        return preg_replace($pattern, '$1 Laravel\Envoy\Slack::make$2->task($task)->send();', $value);
+        return preg_replace($pattern, '$1 Sanuj\Diplomat\Slack::make$2->task($task)->send();', $value);
     }
 
     /**

--- a/src/ConfigurationParser.php
+++ b/src/ConfigurationParser.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Laravel\Envoy;
+namespace Sanuj\Diplomat;
 
 trait ConfigurationParser
 {
@@ -21,7 +21,7 @@ trait ConfigurationParser
      * Get the SSH configuration file instance.
      *
      * @param  string  $user
-     * @return \Laravel\Envoy\SSHConfigFile|null
+     * @return \Sanuj\Diplomat\SSHConfigFile|null
      */
     protected function getSshConfig($user)
     {

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Laravel\Envoy\Console;
+namespace Sanuj\Diplomat\Console;
 
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Console/InitCommand.php
+++ b/src/Console/InitCommand.php
@@ -18,7 +18,7 @@ class InitCommand extends SymfonyCommand
     {
         $this
             ->setName('init')
-            ->setDescription('Create a new Envoy file in the current directory.')
+            ->setDescription('Create a new Diplomat file in the current directory.')
             ->addArgument('host', InputArgument::REQUIRED, 'The host server to initialize with.');
     }
 
@@ -29,13 +29,13 @@ class InitCommand extends SymfonyCommand
      */
     protected function fire()
     {
-        if (file_exists(getcwd().'/Envoy.blade.php')) {
-            $this->output->writeln('<error>Envoy file already exists!</error>');
+        if (file_exists(getcwd().'/Diplomat.blade.php')) {
+            $this->output->writeln('<error>Diplomat file already exists!</error>');
 
             return;
         }
 
-        file_put_contents(getcwd().'/Envoy.blade.php', "@servers(['web' => '".$this->input->getArgument('host')."'])
+        file_put_contents(getcwd().'/Diplomat.blade.php', "@servers(['web' => '".$this->input->getArgument('host')."'])
 
 @task('deploy')
     cd /path/to/site
@@ -43,6 +43,6 @@ class InitCommand extends SymfonyCommand
 @endtask
 ");
 
-        $this->output->writeln('<info>Envoy file created!</info>');
+        $this->output->writeln('<info>Diplomat file created!</info>');
     }
 }

--- a/src/Console/InitCommand.php
+++ b/src/Console/InitCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Laravel\Envoy\Console;
+namespace Sanuj\Diplomat\Console;
 
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -42,7 +42,7 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
         $this->ignoreValidationErrors();
 
         $this->setName('run')
-                ->setDescription('Run an Envoy task.')
+                ->setDescription('Run an Diplomat task.')
                 ->addArgument('task', InputArgument::REQUIRED)
                 ->addOption('continue', null, InputOption::VALUE_NONE, 'Continue running even if a task fails')
                 ->addOption('pretend', null, InputOption::VALUE_NONE, 'Dump Bash script for inspection');
@@ -190,14 +190,14 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
     }
 
     /**
-     * Load the task container instance with the Envoy file.
+     * Load the task container instance with the Diplomat file.
      *
      * @return \Sanuj\Diplomat\TaskContainer
      */
     protected function loadTaskContainer()
     {
-        if (! file_exists($envoyFile = getcwd().'/Envoy.blade.php')) {
-            echo "Envoy.blade.php not found.\n";
+        if (! file_exists($envoyFile = getcwd().'/Diplomat.blade.php')) {
+            echo "Diplomat.blade.php not found.\n";
 
             exit(1);
         }

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -42,7 +42,7 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
         $this->ignoreValidationErrors();
 
         $this->setName('run')
-                ->setDescription('Run an Diplomat task.')
+                ->setDescription('Run a Diplomat task.')
                 ->addArgument('task', InputArgument::REQUIRED)
                 ->addOption('continue', null, InputOption::VALUE_NONE, 'Continue running even if a task fails')
                 ->addOption('pretend', null, InputOption::VALUE_NONE, 'Dump Bash script for inspection');

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Laravel\Envoy\Console;
+namespace Sanuj\Diplomat\Console;
 
-use Laravel\Envoy\SSH;
-use Laravel\Envoy\Task;
-use Laravel\Envoy\Compiler;
-use Laravel\Envoy\ParallelSSH;
-use Laravel\Envoy\TaskContainer;
+use Sanuj\Diplomat\SSH;
+use Sanuj\Diplomat\Task;
+use Sanuj\Diplomat\Compiler;
+use Sanuj\Diplomat\ParallelSSH;
+use Sanuj\Diplomat\TaskContainer;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
@@ -83,7 +83,7 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
     /**
      * Get the tasks from the container based on user input.
      *
-     * @param  \Laravel\Envoy\TaskContainer  $container
+     * @param  \Sanuj\Diplomat\TaskContainer  $container
      * @return void
      */
     protected function getTasks($container)
@@ -100,7 +100,7 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
     /**
      * Run the given task out of the container.
      *
-     * @param  \Laravel\Envoy\TaskContainer  $container
+     * @param  \Sanuj\Diplomat\TaskContainer  $container
      * @param  string  $task
      * @return null|int|void
      */
@@ -130,7 +130,7 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
     /**
      * Run the given task and return the exit code.
      *
-     * @param  \Laravel\Envoy\Task  $task
+     * @param  \Sanuj\Diplomat\Task  $task
      * @return int
      */
     protected function runTaskOverSSH(Task $task)
@@ -150,7 +150,7 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
     /**
      * Run the given task and return the exit code.
      *
-     * @param  \Laravel\Envoy\Task  $task
+     * @param  \Sanuj\Diplomat\Task  $task
      * @return int
      */
     protected function passToRemoteProcessor(Task $task)
@@ -192,7 +192,7 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
     /**
      * Load the task container instance with the Envoy file.
      *
-     * @return \Laravel\Envoy\TaskContainer
+     * @return \Sanuj\Diplomat\TaskContainer
      */
     protected function loadTaskContainer()
     {
@@ -251,8 +251,8 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
     /**
      * Get the SSH processor for the task.
      *
-     * @param  \Laravel\Envoy\Task  $task
-     * @return \Laravel\Envoy\RemoteProcessor
+     * @param  \Sanuj\Diplomat\Task  $task
+     * @return \Sanuj\Diplomat\RemoteProcessor
      */
     protected function getRemoteProcessor(Task $task)
     {

--- a/src/Console/SshCommand.php
+++ b/src/Console/SshCommand.php
@@ -21,7 +21,7 @@ class SshCommand extends \Symfony\Component\Console\Command\Command
     {
         $this
             ->setName('ssh')
-            ->setDescription('Connect to an Envoy server.')
+            ->setDescription('Connect to an Diplomat server.')
             ->addArgument('name', InputArgument::OPTIONAL, 'The name of the server.')
             ->addOption('user', null, InputOption::VALUE_OPTIONAL, 'The name of the user.');
     }
@@ -57,14 +57,14 @@ class SshCommand extends \Symfony\Component\Console\Command\Command
     }
 
     /**
-     * Load the task container instance with the Envoy file.
+     * Load the task container instance with the Diplomat file.
      *
      * @return \Sanuj\Diplomat\TaskContainer
      */
     protected function loadTaskContainer()
     {
         with($container = new TaskContainer)->loadServers(
-            getcwd().'/Envoy.blade.php', new Compiler, []
+            getcwd().'/Diplomat.blade.php', new Compiler, []
         );
 
         return $container;

--- a/src/Console/SshCommand.php
+++ b/src/Console/SshCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Laravel\Envoy\Console;
+namespace Sanuj\Diplomat\Console;
 
-use Laravel\Envoy\Compiler;
-use Laravel\Envoy\TaskContainer;
-use Laravel\Envoy\ConfigurationParser;
+use Sanuj\Diplomat\Compiler;
+use Sanuj\Diplomat\TaskContainer;
+use Sanuj\Diplomat\ConfigurationParser;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 
@@ -41,7 +41,7 @@ class SshCommand extends \Symfony\Component\Console\Command\Command
     /**
      * Get the server from the task container.
      *
-     * @param  \Laravel\Envoy\TaskContainer  $container
+     * @param  \Sanuj\Diplomat\TaskContainer  $container
      * @throws \InvalidArgumentException
      * @return string
      */
@@ -59,7 +59,7 @@ class SshCommand extends \Symfony\Component\Console\Command\Command
     /**
      * Load the task container instance with the Envoy file.
      *
-     * @return \Laravel\Envoy\TaskContainer
+     * @return \Sanuj\Diplomat\TaskContainer
      */
     protected function loadTaskContainer()
     {

--- a/src/Console/SshCommand.php
+++ b/src/Console/SshCommand.php
@@ -21,7 +21,7 @@ class SshCommand extends \Symfony\Component\Console\Command\Command
     {
         $this
             ->setName('ssh')
-            ->setDescription('Connect to an Diplomat server.')
+            ->setDescription('Connect to a Diplomat server.')
             ->addArgument('name', InputArgument::OPTIONAL, 'The name of the server.')
             ->addOption('user', null, InputOption::VALUE_OPTIONAL, 'The name of the user.');
     }

--- a/src/Console/TasksCommand.php
+++ b/src/Console/TasksCommand.php
@@ -17,7 +17,7 @@ class TasksCommand extends \Symfony\Component\Console\Command\Command
     protected function configure()
     {
         $this->setName('tasks')
-                ->setDescription('Lists all Envoy tasks and macros.');
+                ->setDescription('Lists all Diplomat tasks and macros.');
     }
 
     /**
@@ -67,14 +67,14 @@ class TasksCommand extends \Symfony\Component\Console\Command\Command
     }
 
     /**
-     * Load the task container instance with the Envoy file.
+     * Load the task container instance with the Diplomat file.
      *
      * @return \Sanuj\Diplomat\TaskContainer
      */
     protected function loadTaskContainer()
     {
-        if (! file_exists($envoyFile = getcwd().'/Envoy.blade.php')) {
-            echo "Envoy.blade.php not found.\n";
+        if (! file_exists($envoyFile = getcwd().'/Diplomat.blade.php')) {
+            echo "Diplomat.blade.php not found.\n";
 
             exit(1);
         }

--- a/src/Console/TasksCommand.php
+++ b/src/Console/TasksCommand.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Laravel\Envoy\Console;
+namespace Sanuj\Diplomat\Console;
 
-use Laravel\Envoy\Compiler;
-use Laravel\Envoy\TaskContainer;
+use Sanuj\Diplomat\Compiler;
+use Sanuj\Diplomat\TaskContainer;
 
 class TasksCommand extends \Symfony\Component\Console\Command\Command
 {
@@ -39,7 +39,7 @@ class TasksCommand extends \Symfony\Component\Console\Command\Command
     /**
      * List the tasks from the container.
      *
-     * @param  \Laravel\Envoy\TaskContainer  $container
+     * @param  \Sanuj\Diplomat\TaskContainer  $container
      * @return void
      */
     protected function listTasks($container)
@@ -54,7 +54,7 @@ class TasksCommand extends \Symfony\Component\Console\Command\Command
     /**
      * List the macros from the container.
      *
-     * @param  \Laravel\Envoy\TaskContainer  $container
+     * @param  \Sanuj\Diplomat\TaskContainer  $container
      * @return void
      */
     protected function listMacros($container)
@@ -69,7 +69,7 @@ class TasksCommand extends \Symfony\Component\Console\Command\Command
     /**
      * Load the task container instance with the Envoy file.
      *
-     * @return \Laravel\Envoy\TaskContainer
+     * @return \Sanuj\Diplomat\TaskContainer
      */
     protected function loadTaskContainer()
     {

--- a/src/Diplomat.php
+++ b/src/Diplomat.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Sanuj\Diplomat;
+
+use Symfony\Component\Process\Process;
+
+class Diplomat
+{
+    /**
+     * Output of task.
+     *
+     * @var array
+     */
+    protected $output = [];
+
+/**
+     * Run script on given hosts and return output and exit code.
+     *
+     * @param  array  $hosts
+     * @param  string  $script
+     * @return array
+     */
+    public function run($hosts = [], $script) {
+        $exit_code = $this->runTaskOverSSH(new Task($hosts, null, $script));
+        return [
+            'output' => $this->output,
+            'exit_code' => $exit_code
+        ];
+    }
+
+    /**
+     * Run the given task and update output.
+     *
+     * @param  \Sanuj\Diplomat\Task  $task
+     * @return void
+     */
+    protected function runTaskOverSSH(Task $task) {
+        $ssh = new SSH($task);
+        return $ssh->run($task, function($type, $host, $line) {
+            if (starts_with($line, 'Warning: Permanently added ')) {
+                return;
+            }
+
+            $this->displayOutput($type, $host, $line);
+        });
+
+    }
+
+    /**
+     * Display the given output line.
+     *
+     * @param  int  $type
+     * @param  string  $host
+     * @param  string  $line
+     * @return void
+     */
+    protected function displayOutput($type, $host, $line)
+    {
+        $lines = explode("\n", $line);
+
+        foreach ($lines as $line) {
+            if (strlen(trim($line)) === 0) {
+                continue;
+            }
+
+            if ($type == Process::OUT) {
+                $this->output[] = '['.$host.']: '.trim($line).PHP_EOL;
+            } else {
+                $this->output[] = '['.$host.'] Error: '.trim($line).PHP_EOL;
+            }
+        }
+    }
+}

--- a/src/Hipchat.php
+++ b/src/Hipchat.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Laravel\Envoy;
+namespace Sanuj\Diplomat;
 
 use Httpful\Request;
 
@@ -41,7 +41,7 @@ class Hipchat
      * @param  string  $from
      * @param  string  $message
      * @param  string  $color
-     * @return \Laravel\Envoy\Hipchat
+     * @return \Sanuj\Diplomat\Hipchat
      */
     public static function make($token, $room, $from, $message = null, $color = 'purple')
     {

--- a/src/ParallelSSH.php
+++ b/src/ParallelSSH.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Laravel\Envoy;
+namespace Sanuj\Diplomat;
 
 use Closure;
 use Symfony\Component\Process\Process;
@@ -12,7 +12,7 @@ class ParallelSSH extends RemoteProcessor
     /**
      * Run the given task over SSH.
      *
-     * @param  \Laravel\Envoy\Task  $task
+     * @param  \Sanuj\Diplomat\Task  $task
      * @param  \Closure|null  $callback
      * @return void
      */

--- a/src/RemoteProcessor.php
+++ b/src/RemoteProcessor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Laravel\Envoy;
+namespace Sanuj\Diplomat;
 
 use Closure;
 use Symfony\Component\Process\Process;
@@ -10,7 +10,7 @@ abstract class RemoteProcessor
     /**
      * Run the given task over SSH.
      *
-     * @param  \Laravel\Envoy\Task  $task
+     * @param  \Sanuj\Diplomat\Task  $task
      * @return void
      */
     abstract public function run(Task $task, Closure $callback = null);
@@ -19,7 +19,7 @@ abstract class RemoteProcessor
      * Run the given script on the given host.
      *
      * @param  string  $host
-     * @param  \Laravel\Envoy\Task  $task
+     * @param  \Sanuj\Diplomat\Task  $task
      * @return int
      */
     protected function getProcess($host, Task $task)

--- a/src/SSH.php
+++ b/src/SSH.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Laravel\Envoy;
+namespace Sanuj\Diplomat;
 
 use Closure;
 use Symfony\Component\Process\Process;
@@ -12,7 +12,7 @@ class SSH extends RemoteProcessor
     /**
      * Run the given task over SSH.
      *
-     * @param  \Laravel\Envoy\Task  $task
+     * @param  \Sanuj\Diplomat\Task  $task
      * @param  \Closure|null  $callback
      * @return int
      */

--- a/src/SSHConfigFile.php
+++ b/src/SSHConfigFile.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Laravel\Envoy;
+namespace Sanuj\Diplomat;
 
 class SSHConfigFile
 {
@@ -26,7 +26,7 @@ class SSHConfigFile
      * Parse the given configuration file.
      *
      * @param  string  $file
-     * @return \Laravel\Envoy\SSHConfigFile
+     * @return \Sanuj\Diplomat\SSHConfigFile
      */
     public static function parse($file)
     {
@@ -37,7 +37,7 @@ class SSHConfigFile
      * Parse the given configuration string.
      *
      * @param  string  $string
-     * @return \Laravel\Envoy\SSHConfigFile
+     * @return \Sanuj\Diplomat\SSHConfigFile
      */
     public static function parseString($string)
     {

--- a/src/Slack.php
+++ b/src/Slack.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Laravel\Envoy;
+namespace Sanuj\Diplomat;
 
 use Httpful\Request;
 
@@ -37,7 +37,7 @@ class Slack
      * @param  mixed   $channel
      * @param  string  $message
      * @param  array  $options
-     * @return \Laravel\Envoy\Slack
+     * @return \Sanuj\Diplomat\Slack
      */
     public static function make($hook, $channel = '', $message = null, $options = [])
     {

--- a/src/Task.php
+++ b/src/Task.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Laravel\Envoy;
+namespace Sanuj\Diplomat;
 
 class Task
 {

--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -86,7 +86,7 @@ class TaskContainer
     protected $macroOptions = [];
 
     /**
-     * Silently load the Envoy file into the container.
+     * Silently load the Diplomat file into the container.
      *
      * No data is needed.
      *
@@ -100,7 +100,7 @@ class TaskContainer
     }
 
     /**
-     * Load the Envoy file into the container.
+     * Load the Diplomat file into the container.
      *
      * @param  string  $__path
      * @param  \Sanuj\Diplomat\Compiler  $__compiler
@@ -112,10 +112,10 @@ class TaskContainer
     {
         $__dir = realpath(dirname($__path));
 
-        // First we will compiled the "Blade" Envoy file into plain PHP that we'll include
+        // First we will compiled the "Blade" Diplomat file into plain PHP that we'll include
         // into the current scope so it can register tasks in this task container that
         // is also in the current scope. We will extract this other data into scope.
-        $__envoyPath = $this->writeCompiledEnvoyFile(
+        $__envoyPath = $this->writeCompiledDiplomatFile(
             $__compiler, $__path, $__serversOnly
         );
 
@@ -123,7 +123,7 @@ class TaskContainer
 
         ob_start() && extract($__data);
 
-        // Here we will include the compiled Envoy file so it can register tasks into this
+        // Here we will include the compiled Diplomat file so it can register tasks into this
         // container instance. Then we will delete the PHP version of the file because
         // it is no longer needed once we have used it to register in the container.
         include $__envoyPath;
@@ -136,17 +136,17 @@ class TaskContainer
     }
 
     /**
-     * Write the compiled Envoy file to disk.
+     * Write the compiled Diplomat file to disk.
      *
      * @param  \Sanuj\Diplomat\Compiler  $compiler
      * @param  string  $path
      * @param  bool  $serversOnly
      * @return string
      */
-    protected function writeCompiledEnvoyFile($compiler, $path, $serversOnly)
+    protected function writeCompiledDiplomatFile($compiler, $path, $serversOnly)
     {
         file_put_contents(
-            $envoyPath = getcwd().'/Envoy'.md5_file($path).'.php',
+            $envoyPath = getcwd().'/Diplomat'.md5_file($path).'.php',
             $compiler->compile(file_get_contents($path), $serversOnly)
         );
 
@@ -249,7 +249,7 @@ class TaskContainer
             return $path;
         } elseif (($path = realpath($file.'.blade.php')) !== false) {
             return $path;
-        } elseif (($path = realpath(getcwd().'/vendor/'.$file.'/Envoy.blade.php')) !== false) {
+        } elseif (($path = realpath(getcwd().'/vendor/'.$file.'/Diplomat.blade.php')) !== false) {
             return $path;
         } elseif (($path = realpath(__DIR__.'/'.$file.'.blade.php')) !== false) {
             return $path;

--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -163,9 +163,11 @@ class TaskContainer
         foreach ($this->tasks as $name => &$script) {
             $callback = function ($m) { return $m[1].$this->tasks[$m[2]]; };
 
-            $script = $this->trimSpaces(
-                preg_replace_callback("/(\s*)@run\('(.*)'\)/", $callback, $script)
-            );
+            // $script = $this->trimSpaces(
+            //     preg_replace_callback("/(\s*)@run\('(.*)'\)/", $callback, $script)
+            // );
+
+            $script = preg_replace_callback("/(\s*)@run\('(.*)'\)/", $callback, $script);
         }
     }
 
@@ -386,7 +388,8 @@ class TaskContainer
      */
     public function endMacro()
     {
-        $macro = explode(PHP_EOL, $this->trimSpaces(trim(ob_get_clean())));
+        // $macro = explode(PHP_EOL, $this->trimSpaces(trim(ob_get_clean())));
+        $macro = explode(PHP_EOL, trim(ob_get_clean()));
 
         $this->macros[array_pop($this->macroStack)] = $macro;
     }

--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Laravel\Envoy;
+namespace Sanuj\Diplomat;
 
 use Closure;
 use Illuminate\Support\Arr;
@@ -91,7 +91,7 @@ class TaskContainer
      * No data is needed.
      *
      * @param  string  $path
-     * @param  \Laravel\Envoy\Compiler  $compiler
+     * @param  \Sanuj\Diplomat\Compiler  $compiler
      * @return void
      */
     public function loadServers($path, Compiler $compiler)
@@ -103,7 +103,7 @@ class TaskContainer
      * Load the Envoy file into the container.
      *
      * @param  string  $__path
-     * @param  \Laravel\Envoy\Compiler  $__compiler
+     * @param  \Sanuj\Diplomat\Compiler  $__compiler
      * @param  array  $__data
      * @param  bool  $__serversOnly
      * @return void
@@ -138,7 +138,7 @@ class TaskContainer
     /**
      * Write the compiled Envoy file to disk.
      *
-     * @param  \Laravel\Envoy\Compiler  $compiler
+     * @param  \Sanuj\Diplomat\Compiler  $compiler
      * @param  string  $path
      * @param  bool  $serversOnly
      * @return string
@@ -318,7 +318,7 @@ class TaskContainer
      * @param  string  $task
      * @param  array  $macroOptions
      * @throws \Exception
-     * @return \Laravel\Envoy\Task
+     * @return \Sanuj\Diplomat\Task
      */
     public function getTask($task, array $macroOptions = [])
     {

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Laravel\Envoy;
+namespace Sanuj\Diplomat;
 
 class CompilerTest extends TestCase
 {

--- a/tests/DiplomatTest.php
+++ b/tests/DiplomatTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Sanuj\Diplomat;
+
+class DiplomatTest extends TestCase
+{
+	public function test_it_returns_output_and_exit_code_on_one_host()
+    {
+    	$host = ['127.0.0.1'];
+        $diplomat = new Diplomat();
+        $returned = $diplomat->run($host, file_get_contents(
+        	__DIR__ . '/../scripts/script.sh'));
+        
+        $expected = $this->expected_return_array($host, 'IT WORKS!', 0);
+        $this->assertEquals($expected, $returned);
+    }
+
+    public function expected_return_array($hosts, $output_lines, $exit_code) {
+    	$lines = explode("\n", $output_lines);
+
+    	$output = [];
+    	foreach($hosts as $host) {
+    		foreach($lines as $line) {
+    			$output[] = '['.$host.']: ' . trim($line) . PHP_EOL;
+    		}
+    	}
+    	return [
+    		'output' => $output,
+    		'exit_code' => $exit_code
+    	];
+    }
+}

--- a/tests/SSHConfigFileTest.php
+++ b/tests/SSHConfigFileTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Laravel\Envoy;
+namespace Sanuj\Diplomat;
 
 class SSHConfigFileTest extends TestCase
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Laravel\Envoy;
+namespace Sanuj\Diplomat;
 
 class TestCase extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
@znck We can use this in `WatchTower` via [this](https://getcomposer.org/doc/05-repositories.md#loading-a-package-from-a-vcs-repository).

- [x] Change names and namespaces. `Envoy` :arrow_right: `Diplomat`
- [x] Stop trimming leading spaces.
- [x] Start running shell scripts from `.sh` files instead of `Diplomat.blade.php`.
- [ ] Add a service provider.
- [ ] Handle Corner cases and more tests.